### PR TITLE
Updated desc

### DIFF
--- a/Data/SmelterRecipes.xml
+++ b/Data/SmelterRecipes.xml
@@ -7,7 +7,7 @@
 		<Costs>
 			<CraftCost>
 				<Name>Copper Ore</Name>
-				<Amount>1</Amount>
+				<Amount>16</Amount>
 			</CraftCost>
 		</Costs>
 		<Description>Copper bars are refined Copper usable for crafting.</Description>
@@ -39,11 +39,11 @@
 	<CraftData>
 		<Key>lithium bar</Key>
 		<CraftedName>Lithium Bar</CraftedName>
-		<CraftedAmount>8</CraftedAmount>
+		<CraftedAmount>1</CraftedAmount>
 		<Costs>
 			<CraftCost>
 				<Name>Lithium Ore</Name>
-				<Amount>8</Amount>
+				<Amount>16</Amount>
 			</CraftCost>
 		</Costs>
 		<Description>Lithium bars are refined Lithium usable for crafting.</Description>

--- a/Handbook/Materials/Advanced machine block.xml
+++ b/Handbook/Materials/Advanced machine block.xml
@@ -1,0 +1,24 @@
+<MaterialEntry>
+	<Name>Advanced machine block</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Advanced machine block</Text>
+				</Title>
+				<Icon>
+					<Name>Advanced machine block</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Main building block for advanced machines.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tricks and Tips.</Text>
+				</Header>
+				<Paragraph><Text>These machines are constructed in a specific pattern. Only after building the complete pattern you will see the functional machine. Removing one block will again remove the machine.</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Auto Builder.xml
+++ b/Handbook/Materials/Auto Builder.xml
@@ -1,0 +1,29 @@
+<MaterialEntry>
+	<Name>Auto Builder</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Auto Builder</Text>
+				</Title>
+				<Icon>
+					<Name>Auto Builder</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Can construct regular conveyor lines up to 64 blocks in a given direction!</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tips and Tricks!</Text>
+				</Header>
+				<Paragraph><Text>- This machine need quite some power to work at full speed!</Text></Paragraph>
+				<Paragraph><Text>- A hopper is needed to feed the conveyor blocks.</Text></Paragraph>
+				<Paragraph><Text>- Do no use any other blocks! Cannot place any other blocks!</Text></Paragraph>
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text>- Attaching a hopper with transport pipes will build regular conveyor lines, not transport pipes!</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Bedrock.xml
+++ b/Handbook/Materials/Bedrock.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Bedrock</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Bedrock</Text>
+				</Title>
+				<Icon>
+					<Name>Bedrock</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>One of the general rock types. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Blue Canvas.xml
+++ b/Handbook/Materials/Blue Canvas.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Blue Canvas</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Blue Canvas</Text>
+				</Title>
+				<Icon>
+					<Name>Blue Canvas</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Full blue beautification block.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Chevron Sign 2.xml
+++ b/Handbook/Materials/Chevron Sign 2.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Chevron Sign 2</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Chevron Sign 2</Text>
+				</Title>
+				<Icon>
+					<Name>Chevron Sign 2</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Yellow and black arrow-marked block. Can't be turned. No manufacturing plant required to craft.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Chevron Sign.xml
+++ b/Handbook/Materials/Chevron Sign.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Chevron Sign</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Chevron Sign</Text>
+				</Title>
+				<Icon>
+					<Name>Chevron Sign</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Red and white arrow-marked block. Can't be turned. No manufacturing plant required to craft.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Chilled cavern stone.xml
+++ b/Handbook/Materials/Chilled cavern stone.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Chilled Cavern Stone</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Chilled Cavern Stone</Text>
+				</Title>
+				<Icon>
+					<Name>Chilled Cavern Stone</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Main block type between -215 ish and -270 ish. The block causes no cold itself, although the caverns in which you find them are very cold. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Deep Stone.xml
+++ b/Handbook/Materials/Deep Stone.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Deep Stone</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Deep Stone</Text>
+				</Title>
+				<Icon>
+					<Name>Deep Stone</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Main block type beneath -65 ish. Chilled and poisonous caverns excluded. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Deployed Explosive.xml
+++ b/Handbook/Materials/Deployed Explosive.xml
@@ -1,0 +1,36 @@
+<MaterialEntry>
+	<Name>Deployed Explosive</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Deployed Explosive</Text>
+				</Title>
+				<Icon>
+					<Name>Deployed Explosive</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Chargable bomb with increased radius depending on charge level.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tips and Tricks!</Text>
+				</Header>
+				<Paragraph><Text>- This machine needs increasing amounts of power!</Text></Paragraph>
+				<Paragraph><Text>- Level 1 = 100 energy.</Text></Paragraph>
+				<Paragraph><Text>- Level 2 = 1000 energy.</Text></Paragraph>
+				<Paragraph><Text>- Level 3 = 10 000 energy.</Text></Paragraph>
+				<Paragraph><Text>- Level 4 = 100 000 energy.</Text></Paragraph>
+				<Paragraph><Text>- Level 5 = 1 000 000 energy.</Text></Paragraph>
+				<Paragraph><Text>- Level 6 = 10 000 000 energy.</Text></Paragraph>
+				<Paragraph><Text>- And so on!</Text></Paragraph>
+				<Paragraph><Text>- Intermediate levels of energy give no extra blast radius!</Text></Paragraph>
+				<Paragraph><Text>- Reaching level 6 with the current energy production implemented will already be a challenge!</Text></Paragraph>
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text> Has a very shot fuse! Blowing up your base by accident is a thing!</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Diamond Crystal.xml
+++ b/Handbook/Materials/Diamond Crystal.xml
@@ -1,0 +1,24 @@
+<MaterialEntry>
+	<Name>Diamond Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Diamond Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Diamond Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>A diamond crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth 0 to -75.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tricks and Tips.</Text>
+				</Header>
+				<Paragraph><Text>These semi-open caves are best approached from the surface.</Text></Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Emerald Crystal.xml
+++ b/Handbook/Materials/Emerald Crystal.xml
@@ -1,0 +1,20 @@
+<MaterialEntry>
+	<Name>Emerald Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Emerald Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Emerald Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>An emerald crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth -75 to -150.</Text>
+				</Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Geiger.xml
+++ b/Handbook/Materials/Geiger.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Geiger</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Geiger</Text>
+				</Title>
+				<Icon>
+					<Name>Geiger</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Materials needed not yet implemented!</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Green Canvas.xml
+++ b/Handbook/Materials/Green Canvas.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Green Canvas</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Green Canvas</Text>
+				</Title>
+				<Icon>
+					<Name>Green Canvas</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Full green beautification block.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Leaves.xml
+++ b/Handbook/Materials/Leaves.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Leaves</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Leaves</Text>
+				</Title>
+				<Icon>
+					<Name>Leaves</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Can be collected from trees. Basic ingredient for beautification blocks. The block can be placed. Can be crushed in the macerator.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Macerator.xml
+++ b/Handbook/Materials/Macerator.xml
@@ -1,0 +1,25 @@
+<MaterialEntry>
+	<Name>Macerator</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Macerator</Text>
+				</Title>
+				<Icon>
+					<Name>Macerator</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Energy dependent machine that can crush almost every block into oblivion. In rare occasions useful ore will be found in return!</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tips and Tricks!</Text>
+				</Header>
+				<Paragraph><Text>- This machine need quite some power to work at full speed!</Text></Paragraph>
+				<Paragraph><Text>- A hopper is needed to feed items to the machine AND to deposit the ore found by the macerator.</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Mass Storage Block.xml
+++ b/Handbook/Materials/Mass Storage Block.xml
@@ -1,0 +1,24 @@
+<MaterialEntry>
+	<Name>Mass Storage Block</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Mass Storage Block</Text>
+				</Title>
+				<Icon>
+					<Name>massstoragecrate</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>This is the base block for automated mass storage. It cannot be accessed manually. Each block can hold a stack of 25 items. Placing mass storage blocks side by side creates a larger combined storage.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text>Has nothing to do with the Storage Crate!</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Mass Storage Input Port.xml
+++ b/Handbook/Materials/Mass Storage Input Port.xml
@@ -1,0 +1,24 @@
+<MaterialEntry>
+	<Name>Mass Storage Input Port</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Mass Storage Input Port</Text>
+				</Title>
+				<Icon>
+					<Name>Mass Storage Input Port</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Place this block next to a mass storage block to input items into the mass storage. The block needs a conveyor belt to supply the items 1 by 1. Different item types can be imported by the same input port 1 at a time.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text>Has nothing to do with the Storage Crate!</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Mass Storage Output Port.xml
+++ b/Handbook/Materials/Mass Storage Output Port.xml
@@ -1,0 +1,28 @@
+<MaterialEntry>
+	<Name>Mass Storage Output Port</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Mass Storage Output Port</Text>
+				</Title>
+				<Icon>
+					<Name>Mass Storage Output Port</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Place this block next to a mass storage block to output items from the mass storage. You need to manualy specify one single item you want extracted from the mass storage. If the specified item is available in the mass storage the robot will fetch them one by one and place the item on the build in conveyor.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tips and Tricks!</Text>
+				</Header>
+				<Paragraph><Text>Be aware of the orientation of this block! Just like a regular conveyor it moves the item into a specific direction.</Text></Paragraph>
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text>Has nothing to do with the Storage Crate!</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Red Canvas.xml
+++ b/Handbook/Materials/Red Canvas.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Red Canvas</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Red Canvas</Text>
+				</Title>
+				<Icon>
+					<Name>Red Canvas</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Full red beautification block.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Reinforced Rock.xml
+++ b/Handbook/Materials/Reinforced Rock.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Reinforced Rock</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Reinforced Rock</Text>
+				</Title>
+				<Icon>
+					<Name>Reinforced Rock</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Slighly stronger type of wall for your constructions. No manufacturing plant required for crafting this.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Reinforced Wood.xml
+++ b/Handbook/Materials/Reinforced Wood.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Reinforced Wood</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Reinforced Wood</Text>
+				</Title>
+				<Icon>
+					<Name>Reinforced Wood</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Stronger block to build your wooden walls. No manufacturing plant required to craft.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Rough Hewn Rock.xml
+++ b/Handbook/Materials/Rough Hewn Rock.xml
@@ -1,0 +1,23 @@
+<MaterialEntry>
+	<Name>Rough Hewn Rock</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Rough Hewn Rock</Text>
+				</Title>
+				<Icon>
+					<Name>Rough Hewn Rock</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Main block type just beneath the surface blocks. Used as material for serveral beautification blocks. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>				
+				<Header>
+					<Text>Caution!</Text>
+				</Header>
+				<Paragraph><Text>You may encounter the old version of this block. In your inventory they are converted at game restart.</Text></Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Rubble.xml
+++ b/Handbook/Materials/Rubble.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Rubble</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Rubble</Text>
+				</Title>
+				<Icon>
+					<Name>Rubble</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Found as by-product during manual ore mining. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Ruby Crystal.xml
+++ b/Handbook/Materials/Ruby Crystal.xml
@@ -1,0 +1,20 @@
+<MaterialEntry>
+	<Name>Ruby Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Ruby Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Ruby Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>A ruby crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth -150 to -225.</Text>
+				</Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Sapphire Crystal.xml
+++ b/Handbook/Materials/Sapphire Crystal.xml
@@ -1,0 +1,20 @@
+<MaterialEntry>
+	<Name>Sapphire Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Sapphire Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Sapphire Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>A sapphire crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth -225 to -300.</Text>
+				</Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Snow.xml
+++ b/Handbook/Materials/Snow.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Snow</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Snow</Text>
+				</Title>
+				<Icon>
+					<Name>Snow</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Block type making up the cold surface of the world. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Storage Crate.xml
+++ b/Handbook/Materials/Storage Crate.xml
@@ -1,0 +1,20 @@
+<MaterialEntry>
+	<Name>Storage Crate</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Storage Crate</Text>
+				</Title>
+				<Icon>
+					<Name>Storage Crate</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Read 'chest'. Placing Storage crates next to each other will create a larger combined storage. Each crate has 2 item slots.</Text>
+				</Paragraph>
+        </Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>
+

--- a/Handbook/Materials/Sugalite Crystal.xml
+++ b/Handbook/Materials/Sugalite Crystal.xml
@@ -1,0 +1,24 @@
+<MaterialEntry>
+	<Name>Sugalite Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Sugalite Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Sugalite Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>A sugalite crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth -375 to -2500+.</Text>
+				</Paragraph>
+				<Header>
+					<Text>Tricks and Tips.</Text>
+				</Header>
+				<Paragraph><Text>You may encounter sugalite crystals in all deep caves. It's a rare find. At extreme depths cave generation stops.</Text></Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Topaz Crystal.xml
+++ b/Handbook/Materials/Topaz Crystal.xml
@@ -1,0 +1,20 @@
+<MaterialEntry>
+	<Name>Topaz Crystal</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Topaz Crystal</Text>
+				</Title>
+				<Icon>
+					<Name>Topaz Crystal</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>A topaz crystal is a rare material used as base ingredient for upgrades. It can be found in caves between depth -300 to -375.</Text>
+				</Paragraph>
+				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Toxic Cavern Stone.xml
+++ b/Handbook/Materials/Toxic Cavern Stone.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Toxic Cavern Stone</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Toxic Cavern Stone</Text>
+				</Title>
+				<Icon>
+					<Name>Toxic Cavern Stone</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Main block type between --430 ish and -685 ish. The block causes no poison damage itself, although the caverns in which you find them are filled with poisonous particles. Can be crushed in macerator to possibly extract useful ore. The block can be placed.</Text>
+				</Paragraph>
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Tree Trunk.xml
+++ b/Handbook/Materials/Tree Trunk.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Tree Trunk</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Tree Trunk</Text>
+				</Title>
+				<Icon>
+					<Name>Tree Trunk</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Basic ingredient for Wooden Planks. You can get them by cutting down trees. The block can be placed. No manufacturing plant required to craft Wooden Planks.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/White Canvas.xml
+++ b/Handbook/Materials/White Canvas.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>White Canvas</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>White Canvas</Text>
+				</Title>
+				<Icon>
+					<Name>White Canvas</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Full white beautification block.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Window.xml
+++ b/Handbook/Materials/Window.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Window</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Window</Text>
+				</Title>
+				<Icon>
+					<Name>Window</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>See through beautification block. No manufacturing plant required to craft.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>

--- a/Handbook/Materials/Wooden Planks.xml
+++ b/Handbook/Materials/Wooden Planks.xml
@@ -1,0 +1,19 @@
+<MaterialEntry>
+	<Name>Wooden Planks</Name>
+	<Pages>
+		<Page>
+			<Paragraphs>
+				<Title>
+					<Text>Wooden Planks</Text>
+				</Title>
+				<Icon>
+					<Name>Wooden Planks</Name>
+					<Alignment>Center</Alignment>
+				</Icon>
+				<Paragraph>
+					<Text>Basic ingredient for several beautification blocks. The block can be placed. No manufacturing plant required to craft.</Text>
+				</Paragraph>				
+			</Paragraphs>
+		</Page>				
+	</Pages>
+</MaterialEntry>


### PR DESCRIPTION
I have issues with the icons of:
- chilled cavern stone
- toxic cavern stone
- deep stone
- advanced machine block
- storage crate
- Mass storage Block
- Mass storage input block
- Mass storage output block
- deployed explosive

(and ofc also 'autobuilder' but that's to be expected)
